### PR TITLE
fix page summary html escaping

### DIFF
--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -17,7 +17,7 @@
                 {% if page.description %}
                     {{ page.description }}
                 {% elif page.summary %}
-                    {{ page.summary }}&hellip;
+                    {{ page.summary | safe }}&hellip;
                 {% else %}
                     {% set hide_read_more = true %}
                 {% endif %}


### PR DESCRIPTION
I really like this theme, thanks for creating it!

I noticed the summaries of pages get escaped in the posts template. A simple `| safe` addition fixes it.