### PR TITLE
remove always skipping drafts

### DIFF
--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -1,10 +1,6 @@
 {% macro list_posts(pages) %}
     <ul>
     {%- for page in pages %}
-        {%- if page.draft %}
-            {% continue %}
-        {% endif -%}
-
         <section class="list-item">
             <h1 class="title">
                 <a href={{ page.permalink }}>{{page.title}}</a>

--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -6,7 +6,14 @@
                 <a href={{ page.permalink }}>{{page.title}}</a>
             </h1>
 
-            <time>{{ page.date | date(format="%Y-%m-%d") }}</time>
+            <div class="meta">
+                {%- if page.date %}
+                    <time>{{ page.date | date(format="%Y-%m-%d") }}</time>
+                {% endif -%}
+                {% if page.draft %}
+                    <span class="draft-label">DRAFT</span> 
+                {% endif %}
+            </div>
 
             <br />
             <div class="description">
@@ -59,15 +66,15 @@
             {#<h1 class="title">{{ page.title }}</h1>#}
             {{ post_macros::page_header(title=page.title) }}
 
-            {% if page.date %}
                 <div class="meta">
-                    Posted on {{ page.date | date(format="%Y-%m-%d") }}
+                    {% if page.date %}
+                        Posted on <time>{{ page.date | date(format="%Y-%m-%d") }}</time>
+                    {% endif %}
 
                     {% if page.draft %}
                         <span class="draft-label">DRAFT</span> 
                     {% endif %}
                 </div>
-            {% endif %}
         </div>
 
         {% if page.extra.tldr %}


### PR DESCRIPTION
This fixes #3.
Zola already skips draft pages by default, and includes then when the `--drafts` flag is set.

This PR also fixes that the DRAFTS label only appeared when a date is set. It was also missing from the posts list so I added it inside the pages_list macro.

I also added a missing {% if page.date %} check.