### PR TITLE
refactor posts to section template, add extra section frontmatter variable to overwrite section path

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,4 +1,5 @@
 +++
 paginate_by = 7
-sort_by = "date"
+[extra]
+section_path = "posts/_index.md"
 +++

--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -1,7 +1,5 @@
 +++
 path = "posts"
 title = "Posts"
-template = "posts.html"
-transparent = true
 sort_by = "date"
 +++

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,1 +1,1 @@
-{% extends "posts.html" %}
+{% extends "section.html" %}

--- a/templates/section.html
+++ b/templates/section.html
@@ -1,13 +1,16 @@
 {% extends "base.html" %}
 
 {% block main_content %}
-    {{ post_macros::page_header(title="Posts") }}
+    {% if section.extra.section_path -%}
+        {% set section = get_section(path=section.extra.section_path) %}
+    {% endif -%}
+
+    {{ post_macros::page_header(title=section.title) }}
 
     <main class="list">
         {%- if paginator %}
             {%- set show_pages = paginator.pages -%}
         {% else %}
-            {% set section = get_section(path="posts/_index.md") %}
             {%- set show_pages = section.pages -%}
         {% endif -%}
 


### PR DESCRIPTION
I discovered that the posts template is currently hardcoding the section path and can't really be reused for other sections.
This is done to display the posts on the root page.

This PR refactors the posts template into a more generic `section.html` template which [gets used for all sections by zola](https://www.getzola.org/documentation/templates/pages-sections/#section-variables).
To fix the issue with displaying posts on the root page, I added a custom `section_path` frontmatter variable to overwrite the section used in the template.See the root `_index.html` to how it is used.
