### PR TITLE
fix: index page shows Projects and About instead of blogs

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,4 @@
 +++
-paginate_by = 7
 [extra]
 section_path = "posts/_index.md"
 +++

--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -1,4 +1,5 @@
 +++
+paginate_by = 7
 path = "posts"
 title = "Posts"
 sort_by = "date"


### PR DESCRIPTION
The index page shows Projects and About insted of paginating and showing blogs. This will fix this issue. If this isn't the desired behavious, please close the PR

Before:
![image](https://user-images.githubusercontent.com/38459660/194057753-9694cba7-5152-4f2a-8cac-98eb3bb683f1.png)

After:
![image](https://user-images.githubusercontent.com/38459660/194057864-7a488106-132e-4d80-99dc-bc09c2bb2e1d.png)
