### PR TITLE
feat: Add relationship attribute to social links

### DIFF
--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -4,7 +4,7 @@
 
         <div class="socials">
             {% for social in config.extra.socials %}
-            <a href="{{ social.url }}" class="social">
+            <a rel="me" href="{{ social.url }}" class="social">
                 <img alt={{ social.name }} src="/social_icons/{{ social.icon }}.svg">
             </a>
             {% endfor %}


### PR DESCRIPTION
The "rel" html attribute defines the relationship between the linked resource and the current document. The "me" value indicates, that the current document (zola website) represents the person who owns the linked content. This is necessary for mastodon website verification.

See:
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel
https://docs.joinmastodon.org/user/profile/#verification

I think it's safe to add the `rel` attribute to all social links, not just mastodon. If there are concerns, a conditional could be introduced.