### PR TITLE
Add $ inline math support with mathjax

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ These filenames are relative to the root of the site. In this example, the two C
 ### MathJax
 
 To enable MathJax equation rendering, set the variable `mathjax` to `true` in
-the `extra` section of your config.toml.
+the `extra` section of your config.toml. Set `mathjax_dollar_inline_enable` to 
+`true` to render inline math by surrounding them inside $..$.
 
 ```toml
 [extra]
 mathjax = true
+mathjax_dollar_inline_enable = true
 ```
 ## References
 

--- a/config.toml
+++ b/config.toml
@@ -14,6 +14,8 @@ toc = true
 use_cdn = false
 favicon = "/icon/favicon.png"
 theme = "auto"      
+# mathjax = true
+# mathjax_dollar_inline_enable = true
 
 menu = [
     { name = "/posts", url = "/posts", weight = 1 },

--- a/content/posts/math-symbols-test.md
+++ b/content/posts/math-symbols-test.md
@@ -1,0 +1,17 @@
++++
+title = "Math Symbol Support Test"
+date = "2023-01-06"
++++
+
+# Inline Math
+
+-   $(a+b)^2$ = $a^2 + 2ab + b^2$
+-   A polynomial P of degree d over $\mathbb{F}_p$ is an expression of the form
+    $P(s) = a_0 + a_1 . s + a_2 . s^2 + ... + a_d . s^d$ for some
+    $a_0,..,a_d \in \mathbb{F}_p$
+
+# Displayed Math
+
+$$
+p := (\sum_{k∈I}{c_k.v_k} + \delta_v.t(x))·(\sum_{k∈I}{c_k.w_k} + \delta_w.t(x)) − (\sum_{k∈I}{c_k.y_k} + \delta_y.t(x))
+$$

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -42,7 +42,17 @@
         </noscript>
     {% endif %}
 
+
     {% if config.extra.mathjax | default(value=false) %}
+        {% if config.extra.mathjax_dollar_inline_enable | default(value=false) %}
+            <script>
+            MathJax = {
+              tex: {
+                inlineMath: [['$', '$'], ['\\(', '\\)']]
+              }
+            };
+            </script>
+        {% endif %}
         <script type="text/javascript" id="MathJax-script" async
           src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
         </script>


### PR DESCRIPTION
I wanted to add this because it really bothered me that we have to use `\(..\)` to do inline math by default in mathjax. GitHub markdown supports $..$ inline math properly, and when we open markdown, they'll have it rendered correctly. This doesn't happen with `(\..\)` .  So any post page that uses inline math, when viewed in github won't have correct rendering by default if we use `(\..\)` but it will if we use `$..$`. The $..$ way is also more friendly with pandoc if needed, so I thought adding support for it would be nice.