### PR TITLE
Add meta tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Modern and minimalistic blog theme powered by [Zola](https://getzola.org). See a
 - [X] Analytics using [GoatCounter](https://www.goatcounter.com/)
 - [x] Social Links
 - [x] MathJax Rendering
+- [x] Meta Tags For Individual Pages
 - [ ] Search
 - [ ] Categories
 
@@ -68,6 +69,49 @@ the `extra` section of your config.toml. Set `mathjax_dollar_inline_enable` to
 mathjax = true
 mathjax_dollar_inline_enable = true
 ```
+
+## Config
+
+ ### Customize `<meta/>` tags 
+
+ The following TOML and YAML code will yiled two `<meta/>` tags, `<meta property="og:title" content="the og title"/>`, `<meta property="og:description" content="the og description"/>`. 
+
+ TOML: 
+
+ ```toml
+ title = "post title"
+ description = "post desc"
+ date = "2023-01-01"
+
+ [extra]
+ meta = [
+     {property = "og:title", content = "the og title"},
+     {property = "og:description", content = "the og description"},
+ ]
+ ```
+
+ YAML: 
+
+ ```yaml
+ title: "post title"
+ description: "post desc"
+ date: "2023-01-01"
+ extra: 
+     meta: 
+         - property: "og:title"
+           content: "the og title"
+         - property: "og:description"
+           content: "the og description"
+ ```
+
+ If the `og:title`, the `og:description`, or the "description" are not set, the page's title and description will be used. That is, the following TOML code generates `<meta property="og:title" content="post title"/>`, `<meta property="og:description" content="post desc"/>`, and `<meta property="og:description" content="post desc"/>` as default values. 
+
+ ```toml
+ title = "post title"
+ description = "post desc"
+ date = "2023-01-01"
+ ```
+
 ## References
 
 This theme is based on [archie-zola](https://github.com/XXXMrG/archie-zola/).

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -5,16 +5,62 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+    {% if page.extra.meta %}
+         <!-- the meta data config goes here  -->
+         {% for data in page.extra.meta %}
+             <meta 
+                 {% for key, value in data%}
+                     {% if key == "property" and value == "og:title"%}
+                         {% set_global page_has_og_title = true -%}
+                     {% endif %}
+                     {% if key == "property" and value == "og:description"%}
+                         {% set_global page_has_og_description = true -%}
+                     {% endif %}
+                     {% if key == "name" and value == "description"%}
+                         {% set_global page_has_description = true -%}
+                     {% endif %}
+                     {{ key }}="{{ value }}"
+                {% endfor %}
+            />
+        {% endfor %}
+    {% endif %}
+
     {# Site title #}
     {% set current_path = current_path | default(value="/") %}
     {% if current_path == "/" %}
     <title>
         {{ config.title | default(value="Home") }}
     </title>
+    {% if not page_has_og_title %}
+        <meta property="og:title" content="{{ config.title | default(value="Home") }}" />
+    {% endif %}
+
     {% else %}
     <title>
-        {{ page.title | default(value=config.title) | default(value="Post") }}
+        {% if page.title %} {{ page.title }}
+        {% elif config.title %} {{ config.title }}
+        {% else %} Post {% endif %}
     </title>
+
+        {% if not page_has_og_title %}
+            <meta property="og:title" content="{% if page.title -%}{{ page.title }}{% elif config.title -%}{{ config.title }}{% else -%}Post{% endif -%}" />
+        {% endif %}
+     {% endif %}
+
+     {% if not page_has_og_description %}
+         {% if page.description %}
+             <meta property="og:description" content="{{ page.description }}" />
+         {% elif config.description %}
+             <meta property="og:description" content="{{ config.description }}" />
+         {% endif %}
+     {% endif %}
+
+     {% if not page_has_description %}
+         {% if page.description %}
+             <meta name="description" content="{{ page.description }}" />
+         {% elif config.description %}
+             <meta name="description" content="{{ config.description }}" />
+         {% endif %}
     {% endif %}
 
     {# Favicon #}


### PR DESCRIPTION
* add meta tag support for individual pages
```yaml
...
extra:
  meta: 
    - property: og:title 
      content: the title of the page 
    - property: og:description
      content: the description of the page 
```
The YAML code above will generate `<meta property="og:title" content="the title of the page"/>` and `<meta property="og:description" content="the description of the page"/>`.
* default the `og:title` and `og:description` to the pages' title and description.