### PR TITLE
Fix navigation jumpiness on theme toggle click

### DIFF
--- a/sass/parts/_header.scss
+++ b/sass/parts/_header.scss
@@ -67,6 +67,13 @@ header .main {
   letter-spacing: -0.5px;
 }
 
+#dark-mode-toggle>img {
+  display: none;
+  width: 15px;
+  height: 15px;
+  border: unset;
+}
+
 h1,
 h2,
 h3,

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -19,9 +19,9 @@
 
     {% if config.extra.theme == "toggle" %}
     <nav>
-            <img src="feather/sun.svg" id="sun-icon" style="border: unset; filter: invert(1); display: none" height="15"/>
-            <img src="feather/moon.svg" id="moon-icon" style="border: unset; display: none" height="15" />
         | <a id="dark-mode-toggle" onclick="toggleTheme()" href="#">
+            <img src="feather/sun.svg" id="sun-icon" style="filter: invert(1);" />
+            <img src="feather/moon.svg" id="moon-icon" />
         </a>
         <script src={{ get_url(path="js/themetoggle.js" ) }}></script>
     </nav>

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -19,9 +19,9 @@
 
     {% if config.extra.theme == "toggle" %}
     <nav>
-        | <a id="dark-mode-toggle" onclick="toggleTheme()" href="">
             <img src="feather/sun.svg" id="sun-icon" style="border: unset; filter: invert(1); display: none" height="15"/>
             <img src="feather/moon.svg" id="moon-icon" style="border: unset; display: none" height="15" />
+        | <a id="dark-mode-toggle" onclick="toggleTheme()" href="#">
         </a>
         <script src={{ get_url(path="js/themetoggle.js" ) }}></script>
     </nav>


### PR DESCRIPTION
## Background

Hello!
I noticed a bit of jumpiness toggling between light/dark mode, and saw that some of the HTML could be cleaned up too.

Follows up on #26 

## Changes
- `href=""` -> `href="#"`, no reload
- Moved inline CSS to `header.sass` for #hygeine :)

## Preview

| Before | After |
|-|-|
|<video src="https://github.com/not-matthias/apollo/assets/2782749/c80c7dc0-72bd-4a99-8f2d-b64c810dcf4b" height="77px"></video>|<video src="https://github.com/not-matthias/apollo/assets/2782749/c6e6fa19-3396-4d92-899c-351f122d3afb" height="77px"></video>|




