### PR TITLE
fix: nav.html: closing nav tag inside endif block.

### DIFF
--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -22,6 +22,6 @@
             <img src="/feather/moon.svg" id="moon-icon" />
         </a>
         <script src={{ get_url(path="js/themetoggle.js" ) }}></script>
+        {% endif %}
     </nav>
-    {% endif %}
 </header>


### PR DESCRIPTION
# Issue
Anything other than "toggle" value for theme variable in `config.toml` breaks the website.
# Reason
In `nav.html`, the closing `</nav>` tag is inside the `endif` block. Hence, if the theme is not set to "toggle", the `nav` tag is never closed, and website breaks.