### PR TITLE
add taxonomy templates

### DIFF
--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -37,6 +37,19 @@
 </ul>
 {% endmacro list_posts %}
 
+{% macro list_terms(terms) %}
+    <ul>
+    {%- for term in terms %}
+        <section class="list-item">
+            <h1 class="title">
+                <a href={{ term.permalink }}>{{term.name}}</a>
+            </h1>
+        </section>
+
+    {% endfor -%}
+    </ul>
+{% endmacro list_terms %}
+
 {% macro tags(page, short=false) %}
     {%- if page.taxonomies and page.taxonomies.tags %}
         <span class="post-tags-inline">
@@ -74,7 +87,7 @@
                     {% endif %}
 
                     {% if page.draft %}
-                        <span class="draft-label">DRAFT</span> 
+                        <span class="draft-label">DRAFT</span>
                     {% endif %}
                 </div>
         </div>
@@ -165,7 +178,7 @@
                         <time>{{ page.date | date(format="%Y-%m-%d") }}</time>
                     {% endif -%}
                     {% if page.draft %}
-                        <span class="draft-label">DRAFT</span> 
+                        <span class="draft-label">DRAFT</span>
                     {% endif %}
                 </div>
 

--- a/templates/section.html
+++ b/templates/section.html
@@ -5,17 +5,21 @@
         {% set section = get_section(path=section.extra.section_path) %}
     {% endif -%}
 
-    {{ post_macros::page_header(title=section.title) }}
+    {% block title %}
+        {{ post_macros::page_header(title=section.title) }}
+    {% endblock title %}
 
-    <main class="list">
-        {%- if paginator %}
-            {%- set show_pages = paginator.pages -%}
-        {% else %}
-            {%- set show_pages = section.pages -%}
-        {% endif -%}
+    {% block post_list %}
+        <main class="list">
+            {%- if paginator %}
+                {%- set show_pages = paginator.pages -%}
+            {% else %}
+                {%- set show_pages = section.pages -%}
+            {% endif -%}
 
-        {{ post_macros::list_posts(pages=show_pages) }}
-    </main>
+            {{ post_macros::list_posts(pages=show_pages) }}
+        </main>
+    {% endblock post_list %}
 
     {% if paginator %}
         <ul class="pagination">

--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -1,0 +1,6 @@
+{%extends "base.html"%}
+
+{% block main_content %}
+    {{ post_macros::page_header(title=taxonomy.name) }}
+    {{ post_macros::list_terms(terms=terms) }}
+{% endblock main_content %}

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -1,0 +1,6 @@
+{%extends "base.html"%}
+
+{% block main_content %}
+    {{ post_macros::page_header(title=term.name) }}
+    {{ post_macros::list_posts(pages=term.pages) }}
+{% endblock main_content %}

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -1,6 +1,20 @@
-{%extends "base.html"%}
+{% extends "section.html" %}
 
-{% block main_content %}
+
+{% block title %}
     {{ post_macros::page_header(title=term.name) }}
-    {{ post_macros::list_posts(pages=term.pages) }}
+{% endblock title %}
+
+{% block post_list %}
+    <main class="list">
+        {%- if paginator %}
+            {%- set show_pages = paginator.pages -%}
+        {% else %}
+            {%- set show_pages = term.pages -%}
+        {% endif -%}
+
+        {{ post_macros::list_posts(pages=show_pages) }}
+    </main>
+{% endblock post_list %}
+{% block main_content %}
 {% endblock main_content %}


### PR DESCRIPTION
- adds `taxonomy_list.html` and `taxonomy_single.html` for zola to fall back on when rendering taxonomies
- made it so `taxonomy_single.html` inherits from `section.html`
  - I had to wrap the post list and the title in blocks to override them since they refer to the `section` object explicitly
- added a `list_terms` macro to the macros file to be used in `taxonomy_list.html` 
