### PR TITLE
feat: display section title if provided

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -8,7 +8,7 @@
     {% if page.extra.meta %}
          <!-- the meta data config goes here  -->
          {% for data in page.extra.meta %}
-             <meta 
+             <meta
                  {% for key, value in data%}
                      {% if key == "property" and value == "og:title"%}
                          {% set_global page_has_og_title = true -%}
@@ -38,6 +38,7 @@
     {% else %}
     <title>
         {% if page.title %} {{ page.title }}
+        {% elif section.title %} {{ section.title }}
         {% elif config.title %} {{ config.title }}
         {% else %} Post {% endif %}
     </title>


### PR DESCRIPTION
Currently the [about section](https://not-matthias.github.io/apollo/about/) displays About as title but the [posts section](https://not-matthias.github.io/apollo/posts) and [projects section](https://not-matthias.github.io/apollo/projects/) just displays the site title, even though they both provide a title field:

https://github.com/not-matthias/apollo/blob/4b9787dd5b8ff70167e48f425bc7563196bc3002/content/about.md?plain=1#L2

https://github.com/not-matthias/apollo/blob/4b9787dd5b8ff70167e48f425bc7563196bc3002/content/posts/_index.md?plain=1#L4

This pr changed the behavior to use the section title if provided by the user, otherwise fallback to the site title is available.

For users prefer displaying the site title in section page, ~simply remove the title field in `_index.md` to keep the old behavior~ this is a breaking change, but I think it should be fine.

By the way, if we want to make the title and section header fully customizable, e.g. like [Themes | Zola](https://www.getzola.org/themes/) or [Archie | Home](https://athul.github.io/archie/) style, a new variable seems to be inevitable, and then I could close the pr and let the author to choose between the implementation details.