### PR TITLE
added a homepage!

### DIFF
--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block main_content %}
+    {{ post_macros::home_page(section=section) }}
+{% endblock main_content %}

--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -91,6 +91,17 @@
     </div>
 {% endmacro content %}
 
+{% macro home_page(section) %}
+<main>
+    <article>
+        <section class="body">
+            {{post_macros::page_header(title=section.title)}}
+            {{ section.content | safe }}
+        </section>
+    </article>
+</main>
+{% endmacro home_page %}
+
 {% macro content(page) %}
 <main>
     <article>


### PR DESCRIPTION
fixes #59 

Now, I decided to use the template method, as people may want to use this template more than once. So I provided a new macro and template. 

Here is an example:

```
+++
title= "Welcome to Apollo's Homepage!"
template = "homepage.html"
+++

# apollo

Modern and minimalistic blog theme powered by [Zola](https://getzola.org). See a live preview [here](https://not-matthias.github.io/apollo).

<sub><sup>Named after the greek god of knowledge, wisdom and intellect</sup></sub>

## Features

- [X] Pagination
- [X] Themes (light, dark, auto)
- [X] Projects page
- [X] Analytics using [GoatCounter](https://www.goatcounter.com/) / [Umami](https://umami.is/)
- [x] Social Links
- [x] MathJax Rendering
- [x] Taxonomies
- [x] Meta Tags For Individual Pages
- [ ] Search
- [ ] Categories

## Installation

1. Download the theme
```
git submodule add https://github.com/not-matthias/apollo themes/apollo
```

2. Add `theme = "apollo"` to your `config.toml`
3. Copy the example content

```
cp -r themes/apollo/content content
```

## Options
### MathJax

To enable MathJax equation rendering, set the variable `mathjax` to `true` in
the `extra` section of your config.toml. Set `mathjax_dollar_inline_enable` to 
`true` to render inline math by surrounding them inside $..$.

```toml
[extra]
mathjax = true
mathjax_dollar_inline_enable = true
```

## Config

 ### Customize `<meta/>` tags 

 The following TOML and YAML code will yiled two `<meta/>` tags, `<meta property="og:title" content="the og title"/>`, `<meta property="og:description" content="the og description"/>`. 

 TOML: 

 ```toml
 title = "post title"
 description = "post desc"
 date = "2023-01-01"

 [extra]
 meta = [
     {property = "og:title", content = "the og title"},
     {property = "og:description", content = "the og description"},
 ]
 ```

 YAML: 

 ```yaml
 title: "post title"
 description: "post desc"
 date: "2023-01-01"
 extra: 
     meta: 
         - property: "og:title"
           content: "the og title"
         - property: "og:description"
           content: "the og description"
 ```

 If the `og:title`, the `og:description`, or the "description" are not set, the page's title and description will be used. That is, the following TOML code generates `<meta property="og:title" content="post title"/>`, `<meta property="og:description" content="post desc"/>`, and `<meta property="og:description" content="post desc"/>` as default values. 

 ```toml
 title = "post title"
 description = "post desc"
 date = "2023-01-01"
 ```

## References

This theme is based on [archie-zola](https://github.com/XXXMrG/archie-zola/).
```
```




![CleanShot 2024-06-21 at 21 56 35@2x](https://github.com/not-matthias/apollo/assets/31679231/2c538f8d-3ae6-4ca2-872b-29a7fd55c4db)
![CleanShot 2024-06-21 at 21 56 44@2x](https://github.com/not-matthias/apollo/assets/31679231/becf8b82-0492-4d78-aa20-7571cf220962)


Maybe we should consider using the readme as the home page. It looks pretty good. I would prefer this as a default. 