### PR TITLE
Disable HTML escaping for page's permalink

### DIFF
--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -24,7 +24,7 @@
 
             <div>
                 <h1 class="title">
-                    <a href={{ page.permalink }}>{{page.title}}</a>
+                    <a href={{ page.permalink | safe }}>{{page.title}}</a>
 
                     {% if page.draft %}
                     <span class="draft-label">DRAFT</span>
@@ -43,7 +43,7 @@
                     </div>
 
                     {% if not hide_read_more %}
-                    <a class="readmore" href={{ page.permalink }}>Read more ⟶</a>
+                    <a class="readmore" href={{ page.permalink | safe }}>Read more ⟶</a>
                     {% endif %}
                 </div>
             </div>
@@ -222,7 +222,7 @@
                     {% if page.extra.link_to %}
                     <a href={{ page.extra.link_to }}>{{page.title}}</a>
                     {% else %}
-                    <a href={{ page.permalink }}>{{page.title}}</a>
+                    <a href={{ page.permalink | safe }}>{{page.title}}</a>
                     {% endif %}
                 </h1>
 


### PR DESCRIPTION
I love apollo theme for Zola and I have started to use it for my blog. I found a link to a title is sometimes HTML escaped. According the Zola documentation, page's permalink doesn't need to be HTML escaped. This PR tries to fix it.

> We use the | safe filter because the permalink doesn't need to be HTML escaped (escaping would cause `/` to render as `&#x2F;`).

https://www.getzola.org/documentation/getting-started/overview/#blog-template