### PR TITLE
fix: url builder for mermaid script src & added docs

### DIFF
--- a/content/posts/mermaid.md
+++ b/content/posts/mermaid.md
@@ -9,6 +9,13 @@ tags=["example"]
 comment = true
 +++
 
+This Theme supports [mermaid](https://mermaid.js.org/) markdown diagram rendering.
+
+To use mermaid diagrams in your posts, see the example in the raw markdown code.
+https://raw.githubusercontent.com/not-matthias/apollo/refs/heads/main/content/posts/mermaid.md
+
+## Rendered Example
+
 {% mermaid() %}
 graph LR
     A[Start] --> B[Initialize]

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -170,5 +170,5 @@
             <link rel="stylesheet" href="{{ get_url(path=stylesheet) }}">
         {% endfor %}
     {% endif %}
-    <script src="{{config.base_url | safe }}js/mermaid.js"></script>
+    <script src={{ get_url(path="js/mermaid.js") }}></script>
 </head>


### PR DESCRIPTION
Use `get_url` builder to ensure sites making use of the theme can still use mermaid.
Added some additional docs