### PR TITLE
Remove superfluous second `<html>` tag

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,8 +1,7 @@
 {% import "macros/macros.html" as post_macros %}
 
 <!DOCTYPE html>
-<html lang="en">
-<html class="dark light">
+<html lang="en" class="dark light">
 
 {% include "partials/header.html" %}
 


### PR DESCRIPTION
Two subsequent `<html>` tags were merged into a single one.