### PR TITLE
Support word count on article

### DIFF
--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -122,6 +122,10 @@
                         :: <time>{{ page.reading_time }}</time> Min Read
                     {% endif %}
 
+                    {% if page.word_count %}
+                        :: {{ page.word_count }} Words
+                    {% endif %}
+
                     {# Inline display of tags directly after the date #}
                     {% if page.taxonomies and page.taxonomies.tags %}
                             <span class="tags-label"> :: Tags:</span>


### PR DESCRIPTION
Thank you for this fantastic theme!

This PR adds the option to show the word count on an article page.

<img width="690" alt="Screenshot 2025-02-15 at 10 26 30" src="https://github.com/user-attachments/assets/8a8aa939-76cd-4031-8d3f-4c7a4d09da83" />
