### PR TITLE
clarify mathjax configuration in [extra]

### DIFF
--- a/content/posts/math-symbol.md
+++ b/content/posts/math-symbol.md
@@ -9,7 +9,7 @@ tags=["example"]
 comment = true
 +++
 
-Note: This requires the `mathjax` and `mathjax_dollar_inline_enable` option set to `true`.
+Note: This requires the `mathjax` and `mathjax_dollar_inline_enable` option set to `true` in `[extra]` section.
 
 # Inline Math
 


### PR DESCRIPTION
I was looking at this example post about math notations, and I was setting up my own blog. It took me some time to figure out the `mathjax` configurations need to be in `[extra]` section.

 So I am adding that information directly in the example post.