### PR TITLE
feat: add support for multiple authors in post metadata (closes #114)

### DIFF
--- a/sass/parts/_tags.scss
+++ b/sass/parts/_tags.scss
@@ -6,3 +6,11 @@
     white-space: nowrap !important;
   }
 }
+
+.authors {
+  a::before {
+    content: "@";
+    display: inline;
+    white-space: nowrap !important;
+  }
+}

--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -45,3 +45,5 @@
     </div>
     {% endif %}
 {% endmacro content %}
+
+{% macro site_title() %}{{ config.title | default(value="Home") }}{% endmacro %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -38,7 +38,18 @@
                         {% endif %}
                     {% endif %}
 
-                    {# Inline display of tags directly after the date #}
+                    {# Inline display of authors directly after the date #}
+                    {% if page.taxonomies and page.taxonomies.authors %}
+                        <span class="authors-label"> :: </span>
+                        <span class="authors">
+                            {%- for author in page.taxonomies.authors %}
+                                <a href="{{ get_taxonomy_url(kind='authors', name=author, lang=page.lang) }}"
+                                   class="post-authors">{{ author }}</a>
+                            {% endfor %}
+                        </span>
+                    {% endif %}
+
+                    {# Inline display of tags directly after the authors #}
                     {% if page.taxonomies and page.taxonomies.tags %}
                         <span class="tags-label"> :: </span>
                         <span class="tags">

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -21,10 +21,10 @@
     {# Site title #}
     {% set current_path = current_path | default(value="/") %}
     {% if current_path == "/" %}
-        <title>{{ config.title | default(value="Home") }}</title>
+        <title>{{ post_macros::site_title() }}</title>
         {% if not page_has_og_title %}
             <meta property="og:title"
-                  content="{{ config.title | default(value="Home") }}" />
+                  content="{{ post_macros::site_title() }}" />
         {% endif %}
 
     {% else %}
@@ -128,10 +128,21 @@
     {% endif %}
 
     {# RSS #}
-    <link rel="alternate"
-          type="application/atom+xml"
-          title="{{ config.title }}"
-          href="{{ get_url(path="atom.xml", trailing_slash=false) }}">
+    {% if config.generate_feeds %}
+        {% for feed_filenames in config.feed_filenames %}
+            {% if feed_filenames == "atom.xml" %}
+            <link rel="alternate"
+                  type="application/atom+xml"
+                  title="{{ post_macros::site_title() }}"
+                  href="{{ get_url(path="atom.xml", trailing_slash=false) }}" />
+            {% elif feed_filenames == "rss.xml" %}
+            <link rel="alternate"
+                  type="application/rss+xml"
+                  title="{{ post_macros::site_title() }}"
+                  href="{{ get_url(path="rss.xml", trailing_slash=false) }}" />
+            {% endif %}
+        {% endfor %}
+    {% endif %}
 
 
     {% set theme = config.extra.theme | default(value="toggle") %}

--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -3,7 +3,7 @@
 {% block main_content %}
     <div>
         {% block title %}
-            {{ post_macros::page_header(title="Tags") }}
+            {{ post_macros::page_header(title=taxonomy.name | capitalize) }}
         {% endblock title %}
 
         <main class="tag-list">


### PR DESCRIPTION
This PR adds support for displaying multiple authors in the post metadata.

# What’s changed
- Introduced a new `authors` field in the front matter (`[author1, author2, ...]`)
- Updated the post template to render authors in a tags-like format
- Example output:

```
Posted on 2025-06-21 :: Updated on 2025-06-21 :: @author1 @author2 :: #tag1 #tag2
```

# Motivation
This addresses the discussion in #114 and follows the layout proposed in the comment thread. The goal is to provide a cleaner, more modern display of authors and tags in the metadata section.

# Notes
- If `authors` is not present, the author section is omitted entirely, preserving the original layout format.
- Styling is kept consistent with the current theme.

Closes #114.