### PR TITLE
fix: frontpage, feature section URLs

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -26,16 +26,16 @@ template = "homepage.html"
 
 # Features
 
-- [Light, dark, and auto themes](/posts/configuration#theme-mode-theme)  
-- [Projects page](/projects/)                                 
+- [Light, dark, and auto themes](@/posts/configuration.md#theme-mode-theme)  
+- [Projects page](@/projects/_index.md)                                 
 - [Talks page](https://not-matthias.github.io/talks/)         
-- [Analytics (GoatCounter, Umami)](/posts/configuration#analytics)                                                                                                  
-- [Social media links](/posts/configuration#socials)                                                                                                     
-- [MathJax rendering](/posts/math-symbol/)                    
-- [Taxonomies](/tags/)                                 
-- [Custom homepage](/posts/custom-homepage/)                  
-- [Comments](/posts/configuration#comments-comment)                   
-- [Search functionality](/posts/configuration#search-build-search-index)         
+- [Analytics (GoatCounter, Umami)](@/posts/configuration.md#analytics)                                                                                                  
+- [Social media links](@/posts/configuration.md#socials)                                                                                                     
+- [MathJax rendering](@/posts/math-symbol.md)                    
+- [Taxonomies](/apollo/tags)
+- [Custom homepage](@/posts/custom-homepage.md)                  
+- [Comments](@/posts/configuration.md#comments-comment)                   
+- [Search functionality](@/posts/configuration.md#search-build-search-index)         
 
 Checkout all the [options you can configure](./content/posts/configuration.md) and the [example pages](./content/posts/).
 


### PR DESCRIPTION
Fixes https://github.com/not-matthias/apollo/issues/131

Wherever I could, I've used [Zola internal linking](https://www.getzola.org/documentation/content/linking/), which fixes the markdown internal linking issue. These hyperlinks now render with the base URL taken into account.  

The above however only works for documents that exist before the build. Since taxonomies (e.g. `tags`) are generated dynamically, the `Taxonomies` link wasn't as easy to patch up. I've hardcoded it for now, but I'm not very happy about that approach. Looking for alternatives and I'm open to suggestions!

Regarding the taxonomy URL, the same issue has been [raised here](https://zola.discourse.group/t/link-to-taxonomies/512). `get_taxonomy` could be used to link to the `tags` index, but that'd need to be placed in a template, not in the doc itself I believe. Something like inside a template:
```
{% set tags_taxonomy = get_taxonomy(kind="tags")
{{ tags_taxonomy.permalink }}
```
yields:
```
https://not-matthias.github.io/apollo/tags/
```

Maybe I'm overthinking this, and just hardcoding with `/apollo/tags` is perfectly fine for the sake of the demo. Let me know :grin: 
