### PR TITLE
Improve mobile responsiveness – don't flex shrink `content`

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -60,6 +60,7 @@ body {
   .content {
     width: 100%;
     max-width: var(--page-width);
+    flex-shrink: 0;
     padding-bottom: 1.5rem;
     margin-bottom: 1.5rem;
     word-wrap: break-word;


### PR DESCRIPTION
My take on fixing https://github.com/not-matthias/apollo/issues/134

My understanding is that the narrower the viewport gets, the less space the left/right padding sections take up, without any shrinking to the content. Eventually, the left/right sections hit their min width of 0, and only then the content box starts shrinking, since it needs to stay within the screen bounds.

Here are previews for a couple sizes (widths):
![image](https://github.com/user-attachments/assets/0abab431-a8fe-47ff-870e-22fbda55f66f)
![image](https://github.com/user-attachments/assets/f5a9427d-035b-4664-b28a-ccf605f3ed54)
![image](https://github.com/user-attachments/assets/c082278f-5de1-4148-97e1-fc474448d46a)
![image](https://github.com/user-attachments/assets/8dd116b7-4643-4141-a656-0629498c781f)
![image](https://github.com/user-attachments/assets/d5935008-1f99-4199-9ee3-f4dcfa4e787c)
