### PR TITLE
Adjust the date format in the post list to `%Y-%m-%d` to maintain consistency with other places.

### DIFF
--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -2,7 +2,7 @@
 <li class="list-item">
     <section>
         <div class="post-header">
-            <time>{{ page.date | date(format="%d-%m-%Y") }}</time>
+            <time>{{ page.date | date(format="%Y-%m-%d") }}</time>
 
             <div>
                 <h1 class="title">


### PR DESCRIPTION
Hello, I'm using the apollo theme for my blog and I really like it!

I noticed that the date format in the post list is `%d-%m-%Y`, which is inconsistent with the format on individual post pages, which is `%Y-%m-%d`.

I also checked other date formats used across the project with `rg format templates`, and it seems that `%Y-%m-%d` is used everywhere else. I think it might be a good idea to unify the date format for consistency.