### PR TITLE
Feat: Add video support to project cards

### DIFF
--- a/content/posts/configuration.md
+++ b/content/posts/configuration.md
@@ -303,6 +303,8 @@ Each item in the list should be a separate markdown file in the same directory. 
 - `description`: A short description of the item.
 - `weight`: The order in which the item appears on the page.
 - `local_image`: A path to a local image for the item's thumbnail. See the [Local Image](#local-image) section for more details.
+- `local_video`: A path to a local video for the item's thumbnail. See the [Local Video](#local-video) section for more details.
+- `remote_video`: A URL to a remote video for the item's thumbnail.
 - `link_to`: A URL the card should link to.
 
 # Talks Page
@@ -336,3 +338,24 @@ The path resolution for `local_image` works as follows:
 
 - If the path starts with a `/`, it is treated as an absolute path from the `content` directory. For example, `local_image = "/projects/project-1.jpg"` will resolve to `content/projects/project-1.jpg`.
 - If the path does not start with a `/`, it is treated as a relative path. The theme will prepend the `section.path` to the `local_image` path. For example, if you are in a page at `content/posts/my-post/index.md` and you set `local_image = "thumbnail.png"`, the theme will look for the image at `posts/my-post/thumbnail.png`.
+
+# Local Video
+
+The `local_video` front matter parameter allows you to specify a path to a local video file that will be displayed as the thumbnail for a page. This is particularly useful for showcasing projects with dynamic content.
+
+The path resolution for `local_video` works the same as `local_image`:
+
+- If the path starts with a `/`, it is treated as an absolute path from the `content` directory. For example, `local_video = "/projects/demo.mp4"` will resolve to `content/projects/demo.mp4`.
+- If the path does not start with a `/`, it is treated as a relative path. The theme will prepend the `section.path` to the `local_video` path. For example, if you are in a page at `content/projects/my-project/index.md` and you set `local_video = "demo.webm"`, the theme will look for the video at `projects/my-project/demo.webm`.
+
+## Remote Video
+
+The `remote_video` front matter parameter allows you to specify a URL to a remote video file that will be displayed as the thumbnail for a page.
+
+Example usage:
+```toml
+[extra]
+remote_video = "https://example.com/videos/demo.mp4"
+```
+
+The browser will automatically detect the video format, so you don't need to worry about specifying the MIME type.

--- a/content/projects/bacteria_in_porous_media.md
+++ b/content/projects/bacteria_in_porous_media.md
@@ -1,0 +1,10 @@
++++
+title = "Modelling Bacteria Migration in Porous Media"
+description = ""
+weight = 1
+
+[extra]
+local_video = "bacteria-jax.webm"
++++
+
+Example project page

--- a/sass/parts/_cards.scss
+++ b/sass/parts/_cards.scss
@@ -25,6 +25,32 @@
   overflow: hidden;
 }
 
+/* New: Media Wrapper for consistent height */
+.card-media {
+  width: 100%;
+  height: 300px; /* Set a consistent height for all card media (images/videos) */
+  overflow: hidden; /* Hide anything that overflows this container */
+  display: flex; /* Use flexbox to center content if needed */
+  justify-content: center;
+  align-items: center;
+}
+
+.card-image {
+  border: unset;
+  width: 100%;
+  height: 100%; /* Image fills the media wrapper */
+  object-fit: cover; /* Image covers the area, cropping if necessary */
+}
+
+/* New: Styles for video */
+.card-video {
+  width: 100%;
+  height: 100%; /* Video fills the media wrapper */
+  object-fit: cover; /* Video covers the area, cropping if necessary */
+  display: block; /* Removes any extra space below the video */
+}
+
+
 .card-info {
   padding: 0 24px 24px 24px;
 }
@@ -33,10 +59,6 @@
   margin-top: 0.7em;
 }
 
-.card-image {
-  border: unset;
-  width: 100%;
-}
 
 .card-image-placeholder {
   height: 12px;

--- a/templates/cards.html
+++ b/templates/cards.html
@@ -26,12 +26,12 @@
                             {% set video_path = section.path ~ "/" ~ page.extra.local_video %}
                         {% endif %}
                         <video class="card-video" controls autoplay loop muted>
-                            <source src="{{ video_path | safe }}" type="video/mp4">
+                            <source src="{{ video_path | safe }}">
                             Your browser does not support the video tag.
                         </video>
                     {% elif page.extra.remote_video %}
                         <video class="card-video" controls autoplay loop muted>
-                            <source src="{{ page.extra.remote_video | safe }}" type="video/mp4">
+                            <source src="{{ page.extra.remote_video | safe }}">
                             Your browser does not support the video tag.
                         </video>
                     {% else %}

--- a/templates/cards.html
+++ b/templates/cards.html
@@ -5,23 +5,39 @@
     <div class="cards">
         {%- for page in pages %}
             <div class="card">
-                {% if page.extra.local_image %}
-                    {% set path = page.extra.local_image %}
-                    {% if path is not starting_with("/") %}
-                        {% set path = section.path ~ "/" ~ page.extra.local_image %}
-                    {% endif %}
+                <div class="card-media"> {# New wrapper div for consistent media sizing #}
+                    {% if page.extra.local_image %}
+                        {% set path = page.extra.local_image %}
+                        {% if path is not starting_with("/") %}
+                            {% set path = section.path ~ "/" ~ page.extra.local_image %}
+                        {% endif %}
 
-                    {% set image = resize_image(path=path, height=300, op="fit_height", format="webp") %}
-                    <img class="card-image"
-                         alt="{{ page.extra.local_image }}"
-                         src="{{ image.url }}" />
-                {% elif page.extra.remote_image %}
-                    <img class="card-image"
-                         alt="{{ page.extra.remote_image }}"
-                         src="{{ page.extra.remote_image }}" />
-                {% else %}
-                    <div class="card-image-placeholder"></div>
-                {% endif %}
+                        {% set image = resize_image(path=path, height=300, op="fit_height", format="webp") %}
+                        <img class="card-image"
+                             alt="{{ page.extra.local_image }}"
+                             src="{{ image.url }}" />
+                    {% elif page.extra.remote_image %}
+                        <img class="card-image"
+                             alt="{{ page.extra.remote_image }}"
+                             src="{{ page.extra.remote_image }}" />
+                    {% elif page.extra.local_video %}
+                        {% set video_path = page.extra.local_video %}
+                        {% if video_path is not starting_with("/") %}
+                            {% set video_path = section.path ~ "/" ~ page.extra.local_video %}
+                        {% endif %}
+                        <video class="card-video" controls autoplay loop muted>
+                            <source src="{{ video_path | safe }}" type="video/mp4">
+                            Your browser does not support the video tag.
+                        </video>
+                    {% elif page.extra.remote_video %}
+                        <video class="card-video" controls autoplay loop muted>
+                            <source src="{{ page.extra.remote_video | safe }}" type="video/mp4">
+                            Your browser does not support the video tag.
+                        </video>
+                    {% else %}
+                        <div class="card-image-placeholder"></div>
+                    {% endif %}
+                </div> {# End of card-media wrapper #}
 
                 <div class="card-info">
                     <h1 class="card-title">


### PR DESCRIPTION
Hello there!

While using the Apollo theme to build my personal page, I found myself wanting the ability to showcase projects with videos directly on the cards, similar to how images are handled. This PR aims to integrate that functionality.

This pull request introduces the ability to display videos in project cards, alongside existing image support.

- Adds `local_video` and `remote_video` extra variables to project front matter, allowing users to specify video paths.
- Implements `<video>` tag rendering in `cards.html` to display the videos.
- Introduces a `card-media` wrapper and associated CSS in `_cards.scss` to ensure consistent sizing and `object-fit: cover` for both images and videos, preventing layout distortion.
- Includes a new `bacteria_in_porous_media.md` project file and `bacteria-jax.webm` video. These files are added solely as a clear demonstration of this new video feature.
