### PR TITLE
Feat: Google Analytics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Modern and minimalistic blog theme powered by [Zola](https://getzola.org). See a
 - [x] Pagination
 - [x] Themes (light, dark, auto)
 - [x] Projects page
-- [x] Analytics using [GoatCounter](https://www.goatcounter.com/) / [Umami](https://umami.is/)
+- [x] Analytics using [GoatCounter](https://www.goatcounter.com/) / [Umami](https://umami.is/) / [Google Analytics](https://analytics.google.com/)
 - [x] Social Links
 - [x] MathJax Rendering
 - [x] Taxonomies

--- a/config.toml
+++ b/config.toml
@@ -62,3 +62,6 @@ host = "example.com" # default= goatcounter.com
 [extra.analytics.umami]
 website_id = "43929cd1-1e83...."
 host_url = "https://stats.mywebsite.com" # default: https://api-gateway.umami.dev/
+
+[extra.analytics.google]
+tracking_id = "G-XXXXXXXXXX"  # Your Google Analytics tracking ID

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -106,6 +106,19 @@
                 <img src="https://{{ user }}.{{ host }}//count?p={{ current_path }}&t={{ page.title | default(value=config.title) }}">
             </noscript>
         {% endif %}
+
+        {% if config.extra.analytics.google.tracking_id %}
+            {% set tracking_id = config.extra.analytics.google.tracking_id %}
+            
+            <!-- Google tag (gtag.js) -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id={{ tracking_id }}"></script>
+            <script>
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '{{ tracking_id }}');
+            </script>
+        {% endif %}
     {% endif %}
 
     {# Fancy Codeblock #}

--- a/theme.toml
+++ b/theme.toml
@@ -11,6 +11,11 @@ demo = "https://not-matthias.github.io/apollo"
 # Use snake_casing to be consistent with the rest of Zola
 [extra]
 
+# The theme supports the following analytics providers:
+# - goatcounter
+# - umami  
+# - google
+
 [author]
 name = "not-matthias"
 homepage = "https://github.com/not-matthias"


### PR DESCRIPTION
Hi,
I make a small change to add support of Google Analytics for analytics. Hope you enjoy it.

## Summary
- Add Google Analytics integration alongside existing GoatCounter and Umami support
- Update configuration options in config.toml to include Google Analytics tracking ID
- Add Google Analytics script injection in header.html following the same pattern as other analytics providers
- Update documentation in README.md and theme.toml to reflect the new analytics option

## Changes
- **config.toml**: Added `[extra.analytics.google]` configuration section with `tracking_id` parameter
- **templates/partials/header.html**: Added Google Analytics gtag.js script injection logic
- **theme.toml**: Added documentation about supported analytics providers
- **README.md**: Updated features list to include Google Analytics support

## Usage
Users can now enable Google Analytics by setting:
```toml
[extra.analytics]
enabled = true

[extra.analytics.google]
tracking_id = "G-XXXXXXXXXX"
