### PR TITLE
Import fonts.scss in main.scss

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1,3 +1,4 @@
+@import "fonts.scss";
 @import "parts/_cards.scss";
 @import "parts/_code.scss";
 @import "parts/_header.scss";


### PR DESCRIPTION
This pull request makes a minor update to the `sass/main.scss` file by adding an import statement for `fonts.scss`, which ensures that custom fonts are included in the main stylesheet.

I don't know how this was working on your demo, but on my website everything broke when I updated the theme! And this fixed the issue.