### PR TITLE
Add fediverse author attribution

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -33,6 +33,9 @@ mathjax = true
 mathjax_dollar_inline_enable = true
 repo_url = "https://github.com/not-matthias/apollo/tree/main/content/"
 
+fediverse = false    # author attribution
+fediverse_creator = ""    # e.g. @user@instance
+
 menu = [
     { name = "/posts", url = "/posts", weight = 1 },
     { name = "/projects", url = "/projects", weight = 2 },

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -6,6 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="base" content="{{ config.base_url }}">
 
+    {% if config.extra.fediverse %}
+        <meta name="fediverse:creator" content="{{ config.extra.fediverse_creator }}">
+    {% endif %}
+    
     {% if page.extra.meta %}
         <!-- the meta data config goes here  -->
         {% for data in page.extra.meta %}


### PR DESCRIPTION
When using Mastodon, and probably other social networks on the Fediverse that implement the feature, it is possible for users to add author attribution on their website, so that when a link to the latter is published on the platform, the user profile is also inserted under the link preview.

With this PR, a user only needs to toggle the setting `fediverse` to `true`, and add its handle next to `fediverse_creator` in the config file to make it work.
