### PR TITLE
feat: configure opening social links in new tabs

### DIFF
--- a/content/posts/configuration.md
+++ b/content/posts/configuration.md
@@ -87,6 +87,8 @@ Defines the social media links.
   ]
   ```
 
+Social links will open in a new tab if `external_links_target_blank` is set to `true` in the `[markdown]` section of your config.
+
 ## Table of Contents (`toc`)
 
 Enables or disables the table of contents for posts.

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -10,8 +10,13 @@
 
 
         <div class="socials">
+            {% if config.markdown.external_links_target_blank %}
+                {% set link_attrs = 'rel="me noopener" target="_blank"' %}
+            {% else %}
+                {% set link_attrs = 'rel="me"' %}
+            {% endif %}
             {% for social in config.extra.socials %}
-                <a rel="me" href="{{ social.url }}" class="social">
+                <a {{ link_attrs }} href="{{ social.url }}" class="social">
                     <img alt="{{ social.name }}"
                          src="{{ get_url(path="icons/social/" ~ social.icon ~ ".svg") }}">
                 </a>


### PR DESCRIPTION
Zola configuration provides `external_links_target_blank` variable to allow opening URLs in separate tab. This PR uses this variable to control how social links are opened.

Didn't want to create separate config variable to reduce complexity, but open to change

Zola ref: https://www.getzola.org/documentation/getting-started/configuration/
