### PR TITLE
feat: set number of columns and card height for cards template

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Modern and minimalistic blog theme powered by [Zola](https://getzola.org). See a
 - [x] RSS feeds
 - [x] Mermaid diagram support
 - [x] Table of Contents
+- [x] Configurable cards layout
 
 ## Installation
 

--- a/content/posts/configuration.md
+++ b/content/posts/configuration.md
@@ -310,8 +310,14 @@ To create a cards page, you need to create a `_index.md` file in a content direc
 title = "Projects"
 sort_by = "weight"
 template = "cards.html"
+[extra]
+cards_columns = 3
+card_media_height = 200
 +++
 ```
+
+- `cards_columns`: Set exact number of columns (2, 3, 4) or omit for deafult 2-column layout
+- `card_media_height`: Control the height of card media area in pixels (default: 300)
 
 Each item in the list should be a separate markdown file in the same directory. The following front matter is supported:
 
@@ -322,29 +328,6 @@ Each item in the list should be a separate markdown file in the same directory. 
 - `local_video`: A path to a local video for the item's thumbnail. See the [Local Video](#local-video) section for more details.
 - `remote_video`: A URL to a remote video for the item's thumbnail.
 - `link_to`: A URL the card should link to.
-
-## Cards Layout Control
-
-The cards template supports configurable column layouts. Add the following to your section's `_index.md`:
-
-```toml
-+++
-title = "Projects"
-sort_by = "weight"
-template = "cards.html"
-
-[extra]
-cards_columns = "3"  # Set exact number of columns
-+++
-```
-
-**Options:**
-- `cards_columns = "2"` → 2 columns
-- `cards_columns = "3"` → 3 columns  
-- `cards_columns = "4"` → 4 columns
-- No setting → Responsive layout (default)
-
-The system automatically calculates the optimal card width based on the container size and gap spacing.
 
 # Talks Page
 

--- a/content/posts/configuration.md
+++ b/content/posts/configuration.md
@@ -316,7 +316,7 @@ card_media_height = 200
 +++
 ```
 
-- `cards_columns`: Set exact number of columns (2, 3, 4) or omit for deafult 2-column layout
+- `cards_columns`: Set exact number of columns (2, 3, 4) or omit for default 2-column layout
 - `card_media_height`: Control the height of card media area in pixels (default: 300)
 
 Each item in the list should be a separate markdown file in the same directory. The following front matter is supported:

--- a/content/posts/configuration.md
+++ b/content/posts/configuration.md
@@ -323,6 +323,29 @@ Each item in the list should be a separate markdown file in the same directory. 
 - `remote_video`: A URL to a remote video for the item's thumbnail.
 - `link_to`: A URL the card should link to.
 
+## Cards Layout Control
+
+The cards template supports configurable column layouts. Add the following to your section's `_index.md`:
+
+```toml
++++
+title = "Projects"
+sort_by = "weight"
+template = "cards.html"
+
+[extra]
+cards_columns = "3"  # Set exact number of columns
++++
+```
+
+**Options:**
+- `cards_columns = "2"` → 2 columns
+- `cards_columns = "3"` → 3 columns  
+- `cards_columns = "4"` → 4 columns
+- No setting → Responsive layout (default)
+
+The system automatically calculates the optimal card width based on the container size and gap spacing.
+
 # Talks Page
 
 To create a talks page, you need to create a `_index.md` file in the `content/talks` directory. The following front matter is recommended:

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -5,4 +5,5 @@ template = "cards.html"
 
 [extra]
 cards_columns = "3"
+card_media_height = 400
 +++

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -4,6 +4,6 @@ sort_by = "weight"
 template = "cards.html"
 
 [extra]
-cards_columns = "3"
+cards_columns = 3
 card_media_height = 400
 +++

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -2,4 +2,7 @@
 title = "Projects"
 sort_by = "weight"
 template = "cards.html"
+
+[extra]
+cards_columns = "3"
 +++

--- a/sass/parts/_cards.scss
+++ b/sass/parts/_cards.scss
@@ -6,8 +6,9 @@
   --gap: 24px;
   --container-width: 920px;
   --columns: 2;
+  /* Calculate min-width: (total_width - gaps_between_columns) / number_of_columns */
   --min-width: calc((var(--container-width) - (var(--columns) - 1) * var(--gap)) / var(--columns));
-  --media-height: 300px; /* Default card media height */
+  --media-height: 300px;
 }
 
 @media all and (min-width: 640px) {

--- a/sass/parts/_cards.scss
+++ b/sass/parts/_cards.scss
@@ -4,6 +4,7 @@
   gap: 24px;
   padding: 12px 0;
   --cards-min-width: 400px; /* Default min width */
+  --card-media-height: 300px; /* Default card media height */
 }
 
 @media all and (min-width: 640px) {
@@ -29,7 +30,7 @@
 /* New: Media Wrapper for consistent height */
 .card-media {
   width: 100%;
-  height: 300px; /* Set a consistent height for all card media (images/videos) */
+  height: var(--card-media-height); /* Use configurable height */
   overflow: hidden; /* Hide anything that overflows this container */
   display: flex; /* Use flexbox to center content if needed */
   justify-content: center;

--- a/sass/parts/_cards.scss
+++ b/sass/parts/_cards.scss
@@ -1,15 +1,18 @@
 .cards {
   display: grid;
   grid-template-rows: auto;
-  gap: 24px;
+  gap: var(--gap);
   padding: 12px 0;
-  --cards-min-width: 400px; /* Default min width */
-  --card-media-height: 300px; /* Default card media height */
+  --gap: 24px;
+  --container-width: 920px;
+  --columns: 2;
+  --min-width: calc((var(--container-width) - (var(--columns) - 1) * var(--gap)) / var(--columns));
+  --media-height: 300px; /* Default card media height */
 }
 
 @media all and (min-width: 640px) {
   .cards {
-    grid-template-columns: repeat(auto-fill, minmax(var(--cards-min-width), 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(var(--min-width), 1fr));
   }
 }
 
@@ -30,7 +33,7 @@
 /* New: Media Wrapper for consistent height */
 .card-media {
   width: 100%;
-  height: var(--card-media-height); /* Use configurable height */
+  height: var(--media-height); /* Use configurable height */
   overflow: hidden; /* Hide anything that overflows this container */
   display: flex; /* Use flexbox to center content if needed */
   justify-content: center;

--- a/sass/parts/_cards.scss
+++ b/sass/parts/_cards.scss
@@ -3,11 +3,12 @@
   grid-template-rows: auto;
   gap: 24px;
   padding: 12px 0;
+  --cards-min-width: 400px; /* Default min width */
 }
 
 @media all and (min-width: 640px) {
   .cards {
-    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(var(--cards-min-width), 1fr));
   }
 }
 

--- a/templates/cards.html
+++ b/templates/cards.html
@@ -3,15 +3,8 @@
 
 {% macro cards_posts(pages) %}
     {% set media_height = section.extra.card_media_height | default(value=300) %}
-    {% if section.extra.cards_columns %}
-        {% set columns_int = section.extra.cards_columns | int %}
-        {% set gaps = columns_int - 1 %}
-        {% set available_width = 920 - gaps * 24 %}
-        {% set min_width = available_width / columns_int | int %}
-        <div class="cards" style="--cards-min-width: {{ min_width }}px; --card-media-height: {{ media_height }}px;">
-    {% else %}
-        <div class="cards" style="--card-media-height: {{ media_height }}px;">
-    {% endif %}
+    {% set columns_int = section.extra.cards_columns | default(value=2) | int %}
+    <div class="cards" style="--columns: {{ columns_int }}; --media-height: {{ media_height }}px;">
         {%- for page in pages %}
             <div class="card">
                 <div class="card-media">

--- a/templates/cards.html
+++ b/templates/cards.html
@@ -2,14 +2,15 @@
 
 
 {% macro cards_posts(pages) %}
+    {% set media_height = section.extra.card_media_height | default(value=300) %}
     {% if section.extra.cards_columns %}
         {% set columns_int = section.extra.cards_columns | int %}
         {% set gaps = columns_int - 1 %}
         {% set available_width = 920 - gaps * 24 %}
         {% set min_width = available_width / columns_int | int %}
-        <div class="cards" style="--cards-min-width: {{ min_width }}px;">
+        <div class="cards" style="--cards-min-width: {{ min_width }}px; --card-media-height: {{ media_height }}px;">
     {% else %}
-        <div class="cards">
+        <div class="cards" style="--card-media-height: {{ media_height }}px;">
     {% endif %}
         {%- for page in pages %}
             <div class="card">
@@ -21,7 +22,7 @@
                             {% set path = section.path ~ "/" ~ page.extra.local_image %}
                         {% endif %}
 
-                        {% set image = resize_image(path=path, height=300, op="fit_height", format="webp") %}
+                        {% set image = resize_image(path=path, height=media_height, op="fit_height", format="webp") %}
                         <img class="card-image"
                              alt="{{ page.extra.local_image }}"
                              src="{{ image.url }}" />

--- a/templates/cards.html
+++ b/templates/cards.html
@@ -2,7 +2,15 @@
 
 
 {% macro cards_posts(pages) %}
-    <div class="cards">
+    {% if section.extra.cards_columns %}
+        {% set columns_int = section.extra.cards_columns | int %}
+        {% set gaps = columns_int - 1 %}
+        {% set available_width = 920 - gaps * 24 %}
+        {% set min_width = available_width / columns_int | int %}
+        <div class="cards" style="--cards-min-width: {{ min_width }}px;">
+    {% else %}
+        <div class="cards">
+    {% endif %}
         {%- for page in pages %}
             <div class="card">
                 <div class="card-media">

--- a/templates/cards.html
+++ b/templates/cards.html
@@ -3,8 +3,8 @@
 
 {% macro cards_posts(pages) %}
     {% set media_height = section.extra.card_media_height | default(value=300) %}
-    {% set columns_int = section.extra.cards_columns | default(value=2) | int %}
-    <div class="cards" style="--columns: {{ columns_int }}; --media-height: {{ media_height }}px;">
+    {% set columns = section.extra.cards_columns | default(value=2) %}
+    <div class="cards" style="--columns: {{ columns }}; --media-height: {{ media_height }}px;">
         {%- for page in pages %}
             <div class="card">
                 <div class="card-media">


### PR DESCRIPTION
Cards layout has fixed number of columns calculated based on card's min width, and fixed card height.

This PR implements dynamic min width calculation based on provided `cards_columns` count, and customizable card height via `card_media_height`.

Example with 3 columns: https://mtsz.pl/oddam/