### PR TITLE
feat: show section content for section, cards, talks

### DIFF
--- a/templates/cards.html
+++ b/templates/cards.html
@@ -74,6 +74,12 @@
 
     {{ post_macros::page_header(title=section.title) }}
 
+    {% if section.content %}
+        <div class="section-content">
+            {{ section.content | safe }}
+        </div>
+    {% endif %}
+
     <main>
         {%- if paginator %}
             {%- set show_pages = paginator.pages -%}

--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -40,7 +40,7 @@
 
 {% macro page_header(title) %}
     {% if title %}<div class="page-header">{{ title }}</div>{% endif %}
-{% endmacro content %}
+{% endmacro page_header %}
 
 {% macro site_title() %}
     {{ config.title | default(value="Home") }}

--- a/templates/section.html
+++ b/templates/section.html
@@ -9,6 +9,12 @@
         {{ post_macros::page_header(title=section.title) }}
     {% endblock title %}
 
+    {% if section.content %}
+        <div class="section-content">
+            {{ section.content | safe }}
+        </div>
+    {% endif %}
+
     {% block post_list %}
         <main class="post-list">
             {%- if paginator %}

--- a/templates/talks.html
+++ b/templates/talks.html
@@ -151,6 +151,12 @@
 
     {{ post_macros::page_header(title=section.title) }}
 
+    {% if section.content %}
+        <div class="section-content">
+            {{ section.content | safe }}
+        </div>
+    {% endif %}
+
     <main>
         {%- if paginator %}
             {%- set show_pages = paginator.pages -%}


### PR DESCRIPTION
Allow displaying `_index.md` content on `section`, `cards` and `talks` template-based pages.

Example with cards content: https://mtsz.pl/oddam/