### PR TITLE
fix: linenos highlighting for Zola 0.22+ (#168)

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -3,11 +3,11 @@ FROM mcr.microsoft.com/playwright:v1.55.0-noble
 # Install Zola
 RUN apt-get update && \
     apt-get install -y wget && \
-    wget https://github.com/getzola/zola/releases/download/v0.19.2/zola-v0.19.2-x86_64-unknown-linux-gnu.tar.gz && \
-    tar -xzf zola-v0.19.2-x86_64-unknown-linux-gnu.tar.gz && \
+    wget https://github.com/getzola/zola/releases/download/v0.22.1/zola-v0.22.1-x86_64-unknown-linux-gnu.tar.gz && \
+    tar -xzf zola-v0.22.1-x86_64-unknown-linux-gnu.tar.gz && \
     mv zola /usr/local/bin/ && \
     chmod +x /usr/local/bin/zola && \
-    rm zola-v0.19.2-x86_64-unknown-linux-gnu.tar.gz && \
+    rm zola-v0.22.1-x86_64-unknown-linux-gnu.tar.gz && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/content/posts/linenos-test.md
+++ b/content/posts/linenos-test.md
@@ -1,0 +1,117 @@
++++
+title = "Line Highlighting Example"
+date = "2026-04-04"
+
+[taxonomies]
+tags=["test"]
++++
+
+This page demonstrates Zola's [code block annotations](https://www.getzola.org/documentation/content/syntax-highlighting/) supported by the Apollo theme.
+
+# Line Numbers
+
+Use `linenos` to enable line numbering.
+
+    ```rust,linenos
+    fn main() {
+        println!("Hello World");
+        let x = 42;
+    }
+    ```
+
+```rust,linenos
+fn main() {
+    println!("Hello World");
+    let x = 42;
+}
+```
+
+# Single Line Highlighting
+
+Use `hl_lines=2` to highlight a specific line.
+
+    ```rust,linenos,hl_lines=2
+    fn main() {
+        println!("Hello World");
+        let x = 42;
+    }
+    ```
+
+```rust,linenos,hl_lines=2
+fn main() {
+    println!("Hello World");
+    let x = 42;
+}
+```
+
+# Multi-Line Highlighting
+
+Use `hl_lines=2 3` to highlight multiple lines.
+
+    ```rust,linenos,hl_lines=2 3
+    fn main() {
+        println!("Hello World");
+        let x = 42;
+    }
+    ```
+
+```rust,linenos,hl_lines=2 3
+fn main() {
+    println!("Hello World");
+    let x = 42;
+}
+```
+
+# Range Highlighting
+
+Use `hl_lines=1-3` to highlight a range of lines.
+
+    ```rust,linenos,hl_lines=1-3
+    fn main() {
+        println!("Hello World");
+        let x = 42;
+    }
+    ```
+
+```rust,linenos,hl_lines=1-3
+fn main() {
+    println!("Hello World");
+    let x = 42;
+}
+```
+
+# Custom Line Number Start
+
+Use `linenostart=10` to start line numbers at a specific value.
+
+    ```rust,linenos,linenostart=10
+    fn main() {
+        println!("Hello World");
+        let x = 42;
+    }
+    ```
+
+```rust,linenos,linenostart=10
+fn main() {
+    println!("Hello World");
+    let x = 42;
+}
+```
+
+# Hidden Lines
+
+Use `hide_lines=2` to hide specific lines from the output.
+
+    ```rust,linenos,hide_lines=2
+    fn main() {
+        println!("Hello World");
+        let x = 42;
+    }
+    ```
+
+```rust,linenos,hide_lines=2
+fn main() {
+    println!("Hello World");
+    let x = 42;
+}
+```

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759381078,
-        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
 
           # Formatters
           treefmt
-          nodePackages.prettier
+          prettier
           alejandra
           djlint
 

--- a/sass/parts/_code.scss
+++ b/sass/parts/_code.scss
@@ -5,11 +5,6 @@
   --text-color: var(--text-0); // Color of the code text
   --label-color: #f0f0f0; // Text color of the label
 
-  --highlight-color: #f0f0f0;
-}
-
-:root.dark {
-  --highlight-color: #204e8a;
 }
 
 // Define language colors map
@@ -168,14 +163,6 @@ pre {
   padding: 1em;
   position: relative;
 
-  mark {
-    background-color: var(
-      --highlight-color
-    ) !important; // Ensure mark uses the theme background
-    padding: 0;
-    border-radius: 0px;
-  }
-
   code {
     background-color: transparent !important;
     color: var(--text-color);
@@ -183,41 +170,37 @@ pre {
     padding: 0;
     border: none;
     font-family: var(--code-font);
-
-    table {
-      margin: 0;
-      border-collapse: collapse;
-      font-family: var(--code-font);
-
-      mark {
-        display: block;
-        color: unset;
-        padding: 0;
-        background-color: var(--highlight-color) !important;
-        filter: brightness(1.2); // Example to slightly increase brightness
-      }
-    }
-
-    td,
-    th,
-    tr {
-      padding: 0;
-      border-bottom: none;
-      border: none; // Ensure no borders around rows
-    }
-
-    tbody td:first-child {
-      text-align: center;
-      user-select: none;
-      min-width: 60px;
-      border-right: none;
-    }
-
-    tbody tr:nth-child(even),
-    thead tr {
-      background-color: unset;
-    }
   }
+}
+
+// Giallo lines (Zola 0.22+)
+pre.giallo {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+pre.giallo code {
+  display: flex;
+  flex-direction: column;
+}
+
+.giallo-l {
+  padding: 0 1em;
+}
+
+// Giallo highlighted lines — background color set by giallo theme CSS files
+.z-hl {
+  padding-top: 2px;
+  padding-bottom: 2px;
+}
+
+// Giallo line numbers (Zola 0.22+)
+.giallo-ln {
+  display: inline-block;
+  user-select: none;
+  min-width: 1ch;
+  margin-right: 2ch;
+  opacity: 0.8;
 }
 
 .clipboard-button,

--- a/sass/parts/_code.scss
+++ b/sass/parts/_code.scss
@@ -197,6 +197,7 @@ pre.giallo code {
 // Giallo line numbers (Zola 0.22+)
 .giallo-ln {
   display: inline-block;
+  -webkit-user-select: none;
   user-select: none;
   min-width: 1ch;
   margin-right: 2ch;

--- a/static/giallo-light.css
+++ b/static/giallo-light.css
@@ -8,7 +8,7 @@
 }
 
 .z-hl {
-  background-color: #F6F8FA;
+  background-color: #EDF0F3;
 }
 
 .giallo-ln {

--- a/static/giallo-light.css
+++ b/static/giallo-light.css
@@ -8,7 +8,7 @@
 }
 
 .z-hl {
-  background-color: #EDF0F3;
+  background-color: #E0E5EB;
 }
 
 .giallo-ln {

--- a/static/js/codeblock.js
+++ b/static/js/codeblock.js
@@ -16,16 +16,11 @@ const changeIcon = (button, isSuccess) => {
     }, 2000);
 };
 
-// Function to get code text from tables, skipping line numbers
-const getCodeFromTable = (codeBlock) => {
-    return [...codeBlock.querySelectorAll('tr')]
-        .map(row => row.querySelector('td:last-child')?.innerText ?? '')
-        .join('');
-};
-
-// Function to get code text from non-table blocks
-const getNonTableCode = (codeBlock) => {
-    return codeBlock.textContent.trim();
+// Get code text, stripping line numbers if present
+const getCodeText = (codeBlock) => {
+    const clone = codeBlock.cloneNode(true);
+    clone.querySelectorAll('.giallo-ln').forEach(el => el.remove());
+    return clone.textContent.trim();
 };
 
 document.addEventListener('DOMContentLoaded', function () {
@@ -66,9 +61,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         // Attach event listener to copy button
         copyBtn.addEventListener('click', async () => {
-            // Determine if the code is in a table or not
-            const isTable = codeBlock.querySelector('table');
-            const codeToCopy = isTable ? getCodeFromTable(codeBlock) : getNonTableCode(codeBlock);
+            const codeToCopy = getCodeText(codeBlock);
             try {
                 await navigator.clipboard.writeText(codeToCopy);
                 changeIcon(copyBtn, true); // Show success icon

--- a/tests/content/linenos.spec.ts
+++ b/tests/content/linenos.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from '@playwright/test';
+import { TestHelpers } from '../helpers';
+
+test.describe('Line Numbers in Code Blocks (Issue #168)', () => {
+  let helpers: TestHelpers;
+
+  test.beforeEach(async ({ page }) => {
+    helpers = new TestHelpers(page);
+    await page.goto('/posts/linenos-test/');
+    await helpers.waitForPageReady();
+  });
+
+  // Helper: get only code blocks that have line numbers (skip source examples)
+  const linenosBlocks = (page: any) =>
+    page.locator('pre.giallo:has(.giallo-ln)');
+
+  test('line numbers are not user-selectable', async ({ page }) => {
+    const lineNumbers = page.locator('.giallo-ln');
+    const count = await lineNumbers.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < count; i++) {
+      const userSelect = await lineNumbers.nth(i).evaluate(
+        (el: Element) => getComputedStyle(el).userSelect
+      );
+      expect(userSelect).toBe('none');
+    }
+  });
+
+  test('line numbers have proper spacing', async ({ page }) => {
+    const lineNumber = page.locator('.giallo-ln').first();
+    await expect(lineNumber).toBeAttached();
+
+    const styles = await lineNumber.evaluate((el: Element) => {
+      const cs = getComputedStyle(el);
+      return {
+        display: cs.display,
+        marginRight: parseFloat(cs.marginRight),
+        minWidth: parseFloat(cs.minWidth),
+      };
+    });
+
+    expect(styles.display).toBe('inline-block');
+    expect(styles.marginRight).toBeGreaterThan(0);
+    expect(styles.minWidth).toBeGreaterThan(0);
+  });
+
+  test('copy button does not include line numbers', async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    const firstBlock = linenosBlocks(page).first();
+    const copyButton = firstBlock.locator('.clipboard-button');
+    await expect(copyButton).toBeAttached();
+
+    await copyButton.dispatchEvent('click');
+    await page.waitForTimeout(500);
+
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+
+    expect(clipboardText).toContain('fn main()');
+    expect(clipboardText).toContain('println!');
+
+    const lines = clipboardText.trim().split('\n');
+    for (const line of lines) {
+      expect(line).not.toMatch(/^\d+\s*(fn|println|let|})/);
+    }
+  });
+
+  test('highlighted lines have a distinct background', async ({ page }) => {
+    // Second linenos block: hl_lines=2
+    const block = linenosBlocks(page).nth(1);
+
+    const hlBg = await block.locator('.giallo-l.z-hl').first().evaluate(
+      (el: Element) => getComputedStyle(el).backgroundColor
+    );
+    const normalBg = await block.locator('.giallo-l:not(.z-hl)').first().evaluate(
+      (el: Element) => getComputedStyle(el).backgroundColor
+    );
+
+    expect(hlBg).not.toBe(normalBg);
+  });
+
+  test('multi-line highlights apply to all specified lines', async ({ page }) => {
+    // Third linenos block: hl_lines=2 3
+    const block = linenosBlocks(page).nth(2);
+
+    const highlightedLines = block.locator('.giallo-l.z-hl');
+    expect(await highlightedLines.count()).toBe(2);
+
+    const lineNumbers = await highlightedLines.evaluateAll((els: Element[]) =>
+      els.map((el) => el.querySelector('.giallo-ln')?.textContent?.trim())
+    );
+    expect(lineNumbers).toEqual(['2', '3']);
+  });
+
+  test('range highlights apply to all lines in range', async ({ page }) => {
+    // Fourth linenos block: hl_lines=1-3
+    const block = linenosBlocks(page).nth(3);
+
+    const highlightedLines = block.locator('.giallo-l.z-hl');
+    expect(await highlightedLines.count()).toBe(3);
+
+    const lineNumbers = await highlightedLines.evaluateAll((els: Element[]) =>
+      els.map((el) => el.querySelector('.giallo-ln')?.textContent?.trim())
+    );
+    expect(lineNumbers).toEqual(['1', '2', '3']);
+  });
+
+  test('linenostart offsets line numbers', async ({ page }) => {
+    // Fifth linenos block: linenostart=10
+    const block = linenosBlocks(page).nth(4);
+
+    const lineNumbers = await block.locator('.giallo-ln').evaluateAll((els: Element[]) =>
+      els.map((el) => el.textContent?.trim())
+    );
+    expect(lineNumbers).toEqual(['10', '11', '12', '13']);
+  });
+
+  test('hide_lines removes specified lines from output', async ({ page }) => {
+    // Sixth linenos block: hide_lines=2
+    const block = linenosBlocks(page).nth(5);
+
+    const visibleLines = block.locator('.giallo-l');
+    expect(await visibleLines.count()).toBe(3);
+
+    const lineNumbers = await block.locator('.giallo-ln').evaluateAll((els: Element[]) =>
+      els.map((el) => el.textContent?.trim())
+    );
+    expect(lineNumbers).toEqual(['1', '3', '4']);
+  });
+});

--- a/tests/content/linenos.spec.ts
+++ b/tests/content/linenos.spec.ts
@@ -20,9 +20,10 @@ test.describe('Line Numbers in Code Blocks (Issue #168)', () => {
     expect(count).toBeGreaterThan(0);
 
     for (let i = 0; i < count; i++) {
-      const userSelect = await lineNumbers.nth(i).evaluate(
-        (el: Element) => getComputedStyle(el).userSelect
-      );
+      const userSelect = await lineNumbers.nth(i).evaluate((el: Element) => {
+        const cs = getComputedStyle(el) as any;
+        return cs.userSelect ?? cs.webkitUserSelect;
+      });
       expect(userSelect).toBe('none');
     }
   });
@@ -45,7 +46,8 @@ test.describe('Line Numbers in Code Blocks (Issue #168)', () => {
     expect(styles.minWidth).toBeGreaterThan(0);
   });
 
-  test('copy button does not include line numbers', async ({ page, context }) => {
+  test('copy button does not include line numbers', async ({ page, context, browserName }) => {
+    test.skip(browserName === 'webkit', 'WebKit does not support clipboard permissions');
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
 
     const firstBlock = linenosBlocks(page).first();


### PR DESCRIPTION
## Summary

Fixes #168 — line numbers in code blocks were selectable and included when copying.

- Update to Zola 0.22.1 (giallo syntax highlighter replaces table-based linenos)
- Add `user-select: none` and proper spacing to `.giallo-ln` line numbers
- Strip `.giallo-ln` elements before copying in `codeblock.js`
- Add full-width highlight styling for `.z-hl` highlighted lines
- Remove dead table-based linenos code from CSS and JS
- Add reference page (`/posts/linenos-test/`) showing all highlighting features

## Test plan

- [x] 8 Playwright tests covering: user-select, spacing, copy behavior, single/multi/range highlights, linenostart, hide_lines
- [x] All 65 existing tests pass (including 11 visual regression tests)
- [x] Manual review of light/dark theme highlight colors