### PR TITLE
fix: add missing closing brace in CSS

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -16,6 +16,7 @@ template = "homepage.html"
 .homepage-hero-subtitle {
     font-size: 1.25rem;
     margin-bottom: 1rem;
+}
 
 </style>
 


### PR DESCRIPTION
Found a syntax error in .homepage-hero-subtitle. Added the missing closing brace } to ensure the CSS parses correctly and prevents potential styling issues for subsequent rules.