### PR TITLE
feat: export source as flake output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
     in {
+      packages.default = ./.;
       devShells.default = pkgs.mkShell {
         nativeBuildInputs = with pkgs; [
           zola


### PR DESCRIPTION
This enables using apollo as an input of another flake.