### PR TITLE
Generic card links

### DIFF
--- a/content/posts/configuration.md
+++ b/content/posts/configuration.md
@@ -418,6 +418,12 @@ Each item in the list should be a separate markdown file in the same directory. 
 - `local_video`: A path to a local video for the item's thumbnail. See the [Local Video](#local-video) section for more details.
 - `remote_video`: A URL to a remote video for the item's thumbnail.
 - `link_to`: A URL the card should link to.
+- `github`: A URL to item's github repository.
+- `demo`: A URL to item's demo deployment.
+- `card_links`: an array of items describing additional links, each containing:
+  - `url`: the link's URL,
+  - `text`: the link's text (like `"GitHub"` or `"crates.io"`),
+  - `icon`: *(optional)* a social icon, as in [Socials](#socials).
 
 # Talks Page
 

--- a/content/projects/project_6.md
+++ b/content/projects/project_6.md
@@ -1,0 +1,16 @@
++++
+title = "Coverage-Guided Fuzzer"
+description = "Catch edge-case bugs with intelligent input generation"
+weight = 6
+date = 2024-05-01
+
+[extra]
+github = "https://github.com/example/coverage-fuzzer"
+card_links = [
+  { url = "https://example-coverage-fuzzer.rtfd.io", text = "Docs", icon = "globe" },
+  { url = "https://discord.gg/covfuzz", text = "Discord", icon = "discord" },
+]
+tags = ["rust", "llvm", "fuzzing"]
++++
+
+A coverage-guided fuzzing engine that instruments compiled binaries to maximize code-path exploration. It integrates with existing build systems, correlates crashes with minimal reproducing inputs, and ships a triage dashboard for deduplicating and prioritizing findings. Designed for continuous fuzzing at scale with first-class support for sanitizer feedback and structured test input grammars.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 12 : undefined,
   reporter: 'html',
-  timeout: 10000,
+  timeout: 30000,
   use: {
     baseURL: 'http://127.0.0.1:1111',
     trace: 'on-first-retry',

--- a/templates/cards.html
+++ b/templates/cards.html
@@ -79,9 +79,10 @@
                         </p>
                     {% endif %}
 
-                    {% if page.extra.github or page.extra.demo or page.extra.tags %}
+                    {%- set has_card_links = page.extra.card_links or page.extra.github or page.extra.demo -%}
+                    {% if has_card_links or page.extra.tags %}
                         <div class="card-footer">
-                            {% if page.extra.github or page.extra.demo %}
+                            {% if has_card_links %}
                                 <div class="card-links">
                                     {% if page.extra.github %}
                                         {{ components::icon_button(href=page.extra.github,
@@ -93,6 +94,11 @@
                                                                                 text="Demo",
                                                                                 icon="globe") }}
                                     {% endif %}
+                                    {%- for card_link in page.extra.card_links | default(value=[]) -%}
+                                        {{ components::icon_button(href=card_link.url,
+                                                                                text=card_link.text,
+                                                                                icon=card_link.icon | default(value="") ) }}
+                                    {%- endfor -%}
                                 </div>
                             {% endif %}
 

--- a/tests/visual/projects-visual.spec.ts-snapshots/projects-page-Mobile-Chrome-linux.png
+++ b/tests/visual/projects-visual.spec.ts-snapshots/projects-page-Mobile-Chrome-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81acd832deac2453e915dfcb8a3ec01597961d65678d01eb62a28f3cbc56af5f
-size 188088
+oid sha256:7aeb29d178d7750f66698c514e83f502ae633168efb471ecbf246c1c6c28cae1
+size 184884

--- a/tests/visual/projects-visual.spec.ts-snapshots/projects-page-chromium-linux.png
+++ b/tests/visual/projects-visual.spec.ts-snapshots/projects-page-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57cc5a8aeddf041af24d0bbeef894f3b68f57b10b82b48603c2fc2d82dcc64d6
-size 481735
+oid sha256:03003938fa05056e04d96277894b8eeaff7209ae9a50d8d15ea2424fb6534394
+size 462293


### PR DESCRIPTION
I propose a generalization of `extra.github` and `extra.demo`. The user can add any number of "social"-like links. Backwards compatibility is provided - the generic card links appear after github and demo.