### PR TITLE
fix: use page language in html lang attribute

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,7 @@
 {% import "macros/macros.html" as post_macros %}
 
 <!DOCTYPE html>
-<html lang="en" class="dark light">
+<html lang="{{ lang }}" class="dark light">
 
     {% include "partials/header.html" %}
 


### PR DESCRIPTION
## Summary

- use the Zola `lang` template variable for the root HTML element
- keep English output unchanged for the default Apollo configuration
- emit the correct language for sites using `default_language` or multilingual content

The root element currently hardcodes `lang="en"`, even though Zola exposes the current page language to every template.

## Verification

- `zola build` with the default configuration emits `lang=en`
- `zola build` with `default_language = "fr"` emits `lang=fr` on the homepage and posts section
- `git diff --check`

The Docker Playwright suite was attempted, but its web server could not start on an ARM64 host because `Dockerfile.test` downloads the x86_64 Zola binary unconditionally.